### PR TITLE
Add dark mode toggle and SEO metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gsap": "^3.12.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^1.3.0",
     "react-router-dom": "^7.2.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import ExperienceSection from "./components/WorkExperience";
 import FooterSection from "./components/FooterSection";
 import ContactPage from "./components/contact";
 import { Analytics } from '@vercel/analytics/react';
+import SEO from "./common/SEO";
 // ✅ Register GSAP plugins
 gsap.registerPlugin(ScrollTrigger, ScrollToPlugin); // ✅ Add ScrollToPlugin
 
@@ -48,6 +49,11 @@ function App() {
   
   return (
     <>
+      <SEO
+        title="Palukuru Charan Kumar Reddy | Portfolio"
+        description="Portfolio of Palukuru Charan Kumar Reddy, a front-end developer proficient in React.js, TypeScript and modern web technologies."
+        keywords="Charan, React, TypeScript, Front-End Developer, Portfolio"
+      />
       <Header />
       <div className="relative">
         <ScrollProgress />

--- a/src/common/Header.tsx
+++ b/src/common/Header.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
 import gsap from "gsap";
 import { ScrollToPlugin } from "gsap/ScrollToPlugin";
+import { useTheme } from "../context/ThemeContext";
 
 gsap.registerPlugin(ScrollToPlugin);
 
 const Header: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { theme, toggleTheme } = useTheme();
 
   const toggleMenu = () => {
     setIsOpen(!isOpen);
@@ -43,6 +45,9 @@ const Header: React.FC = () => {
             Contact
           </button>
         </nav>
+        <button onClick={toggleTheme} className="hidden md:block ml-4">
+          {theme === 'dark' ? '🌙' : '☀️'}
+        </button>
         <button className="md:hidden" onClick={toggleMenu}>
           {isOpen ? "✖️" : "☰"}
         </button>
@@ -60,6 +65,9 @@ const Header: React.FC = () => {
           </button>
           <button onClick={() => scrollToSection("contact")} className="block w-full text-left py-2 hover:text-blue-200">
             Contact
+          </button>
+          <button onClick={toggleTheme} className="block w-full text-left py-2 hover:text-blue-200">
+            {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
           </button>
         </div>
       )}

--- a/src/common/SEO.tsx
+++ b/src/common/SEO.tsx
@@ -1,0 +1,24 @@
+import { Helmet } from 'react-helmet-async';
+
+interface SEOProps {
+  title: string;
+  description: string;
+  keywords?: string;
+  image?: string;
+  url?: string;
+}
+
+export default function SEO({ title, description, keywords, image = '/CharanImage.jpg', url = 'https://charan-portfolio.com' }: SEOProps) {
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      {keywords && <meta name="keywords" content={keywords} />}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={image} />
+      <meta property="og:url" content={url} />
+      <link rel="canonical" href={url} />
+    </Helmet>
+  );
+}

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+interface ThemeContextProps {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps>({
+  theme: 'dark',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('light', theme === 'light');
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,14 @@ html {
   scroll-padding-top: 2rem; /* Adjust based on your header height */
 }
 
+html.light {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+html.light img {
+  filter: invert(1) hue-rotate(180deg);
+}
+
 body {
   cursor: none;
   background: black;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { HelmetProvider } from 'react-helmet-async'
 import './index.css'
 import App from './App.tsx'
+import { ThemeProvider } from './context/ThemeContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <HelmetProvider>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </HelmetProvider>
   </StrictMode>,
 )

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     './index.html',
     "./src/**/*.{html,js,jsx,ts,tsx}",


### PR DESCRIPTION
## Summary
- enable dark mode via class in Tailwind
- create a theme context and toggle in the header
- add dynamic SEO component using react-helmet-async
- wrap app with providers for Helmet and theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d09eaae8c83249e785a70a91cdfff